### PR TITLE
Re-attempt OSX R 3.4.1 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: f1069bf920e9bc3da6bf43542a3a7ccc3142544d759945115ecade69dd5ccde0
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
 
   rpaths:


### PR DESCRIPTION
It appears that the previous R 3.4.1 build for macOS on master failed because dependencies were not available on the `conda-forge` channel.  Now that those dependencies are available, I incremented the build number and retried the build on Travis.  The build passed, so merging this PR should make r-feather for R 3.4.1 available on macOS.